### PR TITLE
JSCCE-30737 Add basic support for Ubuntu Jammy (22.04 LTS) in repos

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -18,6 +18,7 @@ class fluentbit::repo::debian {
     'Ubuntu' => [
       'xenial',
       'bionic',
+      'jammy',
     ],
     'Raspbian' => [
       'jessie',


### PR DESCRIPTION
Trivial Ubuntu 22.04 LTS support for the module, for testing purposes.